### PR TITLE
Enable push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ TWILIO_PHONE_NUMBER=your_twilio_phone_number
 
 # Optional - SMS Subscribers (comma-separated phone numbers)
 SMS_SUBSCRIBERS=+40712345678,+40723456789
+
+# Web Push
+VAPID_PUBLIC_KEY=your_vapid_public_key
+VAPID_PRIVATE_KEY=your_vapid_private_key
 ```
 
 ### Local Development
@@ -71,6 +75,13 @@ npm run build
 3. **Set Environment Variables**: Add the variables listed above
 4. **Deploy**: Push to main branch for automatic deployment
 
+### Push Notifications
+
+1. Generate VAPID keys using `npx web-push generate-vapid-keys` and add them to your environment variables.
+2. Ensure your browser allows notifications and load the site over HTTPS.
+3. Toggle the "Notificări Push Browser" switch in the settings to subscribe.
+4. A test notification confirms that push is configured correctly.
+
 ## 📡 API Endpoints
 
 ### Weather Data
@@ -86,8 +97,14 @@ Body: { "phoneNumber": "+40712345678" }
 ```
 
 ```
-DELETE /api/sms-subscription  
+DELETE /api/sms-subscription
 Body: { "phoneNumber": "+40712345678" }
+```
+
+### Push Subscription
+```
+POST /api/push-subscription
+Body: { "subscription": { ... } }
 ```
 
 ### Send Alerts

--- a/components/NotificationSettings.tsx
+++ b/components/NotificationSettings.tsx
@@ -9,6 +9,17 @@ import { Label } from '@/components/ui/label';
 import { Bell, Smartphone, Mail, Check, X, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 
+const urlBase64ToUint8Array = (base64String: string) => {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+};
+
 export function NotificationSettings() {
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushSupported, setPushSupported] = useState(false);
@@ -57,8 +68,20 @@ export function NotificationSettings() {
       try {
         const permission = await Notification.requestPermission();
         setPushPermission(permission);
-        
+
         if (permission === 'granted') {
+          const registration = await navigator.serviceWorker.register('/sw.js');
+          const subscription = await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(
+              process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY as string
+            ),
+          });
+          await fetch('/api/push-subscription', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ subscription }),
+          });
           setPushEnabled(true);
           toast.success('Push notifications enabled successfully!');
         } else {

--- a/netlify/functions/push-subscription.ts
+++ b/netlify/functions/push-subscription.ts
@@ -1,0 +1,50 @@
+import type { Handler } from '@netlify/functions';
+import webPush from 'web-push';
+
+const handler: Handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers, body: '' };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method Not Allowed' }) };
+  }
+
+  const publicKey = process.env.VAPID_PUBLIC_KEY;
+  const privateKey = process.env.VAPID_PRIVATE_KEY;
+
+  if (!publicKey || !privateKey) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: 'VAPID keys are not configured' }),
+    };
+  }
+
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const { subscription } = body;
+    webPush.setVapidDetails('mailto:example@example.com', publicKey, privateKey);
+    await webPush.sendNotification(
+      subscription,
+      JSON.stringify({
+        title: 'Wind Warning',
+        message: 'Push notifications enabled!',
+        url: '/',
+      })
+    );
+
+    return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+  } catch (error) {
+    console.error('Push subscription error:', error);
+    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Failed to send push message' }) };
+  }
+};
+
+export { handler };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-resizable-panels": "^2.1.3",
     "recharts": "^2.12.7",
     "resend": "^4.6.0",
+    "web-push": "^3.5.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "3.3.3",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,17 @@
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Wind Warning';
+  const options = {
+    body: data.message || 'New alert',
+    icon: '/favicon.ico',
+    badge: '/favicon.ico',
+    data: data.url || '/'
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  const url = event.notification.data || '/';
+  event.waitUntil(clients.openWindow(url));
+});


### PR DESCRIPTION
## Summary
- add service worker to handle push events
- register push subscription in NotificationSettings
- implement Netlify function to send Web Push test message
- include web-push dependency
- document push configuration and API endpoint in README

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688343983f908331b332caa65553b22b